### PR TITLE
Change warning critical series to be shown by default

### DIFF
--- a/doc/01-About.md
+++ b/doc/01-About.md
@@ -36,12 +36,6 @@ An option to manually merge metrics into one chart could be added in the future.
 We decided to have a fixed set of time ranges to choose from.
 Having user input for the time ranges would increase the complexity of this module.
 
-### Warning and critical series
-
-If available, the warning and critical series are not shown by default.
-Rationale behind this was, that often times these values are many times higher than
-the performance data values. This would cause the actual values to be almost invisible.
-
 ### Custom variables
 
 We decided to use custom variables for graph configuration.

--- a/public/js/module.js
+++ b/public/js/module.js
@@ -24,7 +24,7 @@
         // Where we store data in between autorefresh
         currentSelect = null;
         currentCursor = null;
-        currentSeriesShow = {1: true};
+        currentSeriesShow = {};
         // Where we store the variable selected and the constant timerange
         duration = '';
         defaultDuration = '';
@@ -73,7 +73,8 @@
                 // an autorefresh and new data is being loaded.
                 // _this.currentSelect = {min: 0, max: 0};
                 _this.currentSelect = null;
-                _this.currentSeriesShow = {1: true};
+                // 1: value, 2: warning, 3: critical
+                _this.currentSeriesShow = {};
                 _this.currentCursor = null;
                 _this.duration = this.defaultDuration;
             }
@@ -409,7 +410,7 @@
 
                         // See if there are series options from the last autorefresh
                         // if so we use them, otherwise the default.
-                        let show = this.currentSeriesShow[idx+1];
+                        let show = this.currentSeriesShow[idx+1] ?? true;
                         // Get the style either from the dataset or from CSS
                         let stroke = dataset.stroke ?? valueColor;
                         let fill = dataset.fill ?? this.ensureRgba(valueColor, 0.3);


### PR DESCRIPTION
Since more data means more context for the user. 

In the future we might introduce a global or metric wide toggle option.