### PR TITLE
Extend CustomVarHelper to be able to replace Macros

### DIFF
--- a/library/Perfdatagraphs/Icingadb/CustomVarsHelper.php
+++ b/library/Perfdatagraphs/Icingadb/CustomVarsHelper.php
@@ -6,6 +6,7 @@ use Icinga\Exception\NotFoundError;
 
 use Icinga\Module\Icingadb\Common\Auth;
 use Icinga\Module\Icingadb\Common\Database;
+use Icinga\Module\Icingadb\Common\Macros;
 use Icinga\Module\Icingadb\Model\Host;
 use Icinga\Module\Icingadb\Model\Service;
 
@@ -20,6 +21,7 @@ class CustomVarsHelper
 {
     use Database;
     use Auth;
+    use Macros;
 
     // Name of all the custom variables we use.
     public const CUSTOM_VAR_CONFIG_PREFIX  = 'perfdatagraphs_config';

--- a/library/Perfdatagraphs/Ido/CustomVarsHelper.php
+++ b/library/Perfdatagraphs/Ido/CustomVarsHelper.php
@@ -4,10 +4,12 @@ namespace Icinga\Module\Perfdatagraphs\Ido;
 
 use Icinga\Module\Monitoring\Backend\MonitoringBackend;
 use Icinga\Module\Monitoring\Object\Host;
+use Icinga\Module\Monitoring\Object\Macro;
 use Icinga\Module\Monitoring\Object\MonitoredObject;
 use Icinga\Module\Monitoring\Object\Service;
 
 use Icinga\Exception\NotFoundError;
+use Tests\Icinga\Modules\Monitoring\Application\Views\Helpers\MacroTest;
 
 /**
  * CustomVarsHelper is a helper class to work with custom variables of Icinga objects.
@@ -129,5 +131,15 @@ class CustomVarsHelper
         }
 
         return $data;
+    }
+
+    /**
+     * expandMacros returns the given string with macros being resolved.
+     * This can be used in backend modules when object information are required,
+     * e.g. Graphite templates.
+     */
+    public function expandMacros(string $input, $object): string
+    {
+        return Macro::resolveMacros($input, $object);
     }
 }


### PR DESCRIPTION
This can be used in backend modules when object information are required, e.g. Graphite templates.