### PR TITLE
Change line-chart class name

### DIFF
--- a/library/Perfdatagraphs/Common/PerfdataChart.php
+++ b/library/Perfdatagraphs/Common/PerfdataChart.php
@@ -173,7 +173,8 @@ trait PerfdataChart
         // to the JavaScript part of this module.
         foreach ($datasets as $title => $data) {
             $chart = HtmlElement::create('div', [
-                'class' => 'line-chart',
+                // We use a perfdatagraphs prefix here to avoid overlap with other modules (i.e. Icinga Kubernetes)
+                'class' => 'perfdatagraphs-line-chart',
                 'id' => $elemID . '_' . $title,
                 'data-perfdata' => $data,
             ]);

--- a/public/js/module.js
+++ b/public/js/module.js
@@ -3,7 +3,7 @@
     'use strict';
 
     // The element in which we will add the charts
-    const CHART_CLASS = '.line-chart';
+    const CHART_CLASS = '.perfdatagraphs-line-chart';
     // Names to identify the warning/critical series
     const CHART_WARN_SERIESNAME = 'warning';
     const CHART_CRIT_SERIESNAME = 'critical';


### PR DESCRIPTION
Icinga Kubernetes searches for the same class and breaks our charts. 