### PR TITLE
Destroy uPlot instances before creating new charts

### DIFF
--- a/public/js/module.js
+++ b/public/js/module.js
@@ -237,6 +237,13 @@
             // These are the shared options for all charts
             const baseOpts = this.getChartBaseOptions();
 
+            // Remove leftover eventhandlers and uPlot instances
+            this.plots.forEach((plots, element, map) => {
+                plots.forEach((plot) => {
+                    plot.destroy();
+                });
+            });
+
             // Reset the existing plots map for the new rendering
             this.plots = new Map();
 


### PR DESCRIPTION
Go through all existing plots and destroy them explicitly before clearing the Map

fixes #32