### PR TITLE
fix: don't render in the fetch method

### DIFF
--- a/public/js/module.js
+++ b/public/js/module.js
@@ -86,7 +86,6 @@
                 const perfdata = JSON.parse(elem.getAttribute('data-perfdata'));
 
                 _this.data.set(elem.getAttribute('id'), perfdata);
-                _this.renderCharts();
             }
         }
 


### PR DESCRIPTION
Removed the call to render in the `fetchData` method.

The function is only ever called in `rendered` and it calls `renderCharts` right after.

Furthermore, it was inside the fetch and parsing loop, where it caused all charts to be re-rendered multiple times unnecessarily.