### PR TITLE
Add metric selector to the graphs tab

### DIFF
--- a/library/Perfdatagraphs/ProvidedHook/Icingadb/Tab.php
+++ b/library/Perfdatagraphs/ProvidedHook/Icingadb/Tab.php
@@ -7,6 +7,7 @@ use Icinga\Module\Perfdatagraphs\Common\PerfdataChart;
 use Icinga\Module\Perfdatagraphs\Common\PerfdataSource;
 use Icinga\Module\Perfdatagraphs\Icingadb\IcingaObjectHelper;
 use Icinga\Module\Perfdatagraphs\Model\PerfdataRequest;
+use Icinga\Module\Perfdatagraphs\Widget\MetricSelector;
 
 use Icinga\Module\Icingadb\Hook\TabHook;
 use Icinga\Module\Icingadb\Model\Host;
@@ -14,6 +15,7 @@ use Icinga\Module\Icingadb\Model\Service;
 
 use Icinga\Application\Icinga;
 
+use ipl\Web\Url;
 use ipl\Html\Html;
 use ipl\Html\HtmlElement;
 use ipl\Html\HtmlString;
@@ -108,14 +110,26 @@ class Tab extends TabHook
 
         $response = $source->fetch($request, $customVarsMetrics);
 
-        $limit = -1;
-        $chart = $this->createChart(request: $request, response: $response, filter: $labels, limit: $limit);
-        $content[] = HtmlString::create($chart);
-
-        if (empty($chart)) {
-            $content[] = $this->addError($this->translate('Chart could not be rendered'));
-            return $content;
+        // Collect all available metric labels from the response
+        $availableLabels = [];
+        foreach ($response->getDatasets() as $dataset) {
+            $availableLabels[] = $dataset->getTitle();
         }
+
+        if (!empty($availableLabels)) {
+            // Show the metric selector, charts only render once the user picks at least one
+            $content[] = new MetricSelector($availableLabels, $labels, Url::fromRequest());
+
+            if (!empty($labels)) {
+                $chart = $this->createChart(request: $request, response: $response, filter: $labels, limit: -1);
+                $content[] = HtmlString::create($chart);
+            }
+        } else {
+            // No datasets available, fall through to the standard error/empty rendering
+            $chart = $this->createChart(request: $request, response: $response, filter: $labels, limit: -1);
+            $content[] = HtmlString::create($chart);
+        }
+
 
         return $content;
     }

--- a/library/Perfdatagraphs/Widget/MetricSelector.php
+++ b/library/Perfdatagraphs/Widget/MetricSelector.php
@@ -40,6 +40,11 @@ class MetricSelector extends BaseHtmlElement
             return;
         }
 
+        // data-base-url lets the JS reconstruct URLs for range selections
+        $this->addAttributes([
+            'data-base-url' => $this->baseUrl->without('perfdatagraphs.label')->getAbsoluteUrl(),
+        ]);
+
         $this->add(Html::tag(
             'p',
             ['class' => 'metric-selector-title'],
@@ -75,9 +80,12 @@ class MetricSelector extends BaseHtmlElement
             }
 
             $list->add(Html::tag('li', Html::tag('a', [
-                'href'  => $urlStr,
-                'class' => 'metric-label-link' . ($isSelected ? ' selected' : ''),
+                'href'        => $urlStr,
+                'class'       => 'metric-label-link' . ($isSelected ? ' selected' : ''),
+                'data-label'  => $label,
+                'data-index'  => $index,
             ], $label)));
+            $index++;
         }
 
         $this->add($list);

--- a/library/Perfdatagraphs/Widget/MetricSelector.php
+++ b/library/Perfdatagraphs/Widget/MetricSelector.php
@@ -53,6 +53,7 @@ class MetricSelector extends BaseHtmlElement
 
         $list = Html::tag('ul', ['class' => 'metric-selector-list']);
 
+        $index = 0;
         foreach ($this->availableLabels as $label) {
             $isSelected = in_array($label, $this->selectedLabels, true);
 

--- a/library/Perfdatagraphs/Widget/MetricSelector.php
+++ b/library/Perfdatagraphs/Widget/MetricSelector.php
@@ -57,38 +57,21 @@ class MetricSelector extends BaseHtmlElement
         foreach ($this->availableLabels as $label) {
             $isSelected = in_array($label, $this->selectedLabels, true);
 
-            // Build the new set of selected labels after this toggle
-            if ($isSelected) {
-                $newLabels = array_values(array_filter(
-                    $this->selectedLabels,
-                    fn($l) => $l !== $label
-                ));
-            } else {
-                $newLabels = array_merge($this->selectedLabels, [$label]);
-            }
-
-            // Start from the base URL with all existing label params stripped
-            $urlStr = $this->baseUrl->without('perfdatagraphs.label')->getAbsoluteUrl();
-
-            // Append each desired label as a separate query param
-            if (!empty($newLabels)) {
-                $separator  = strpos($urlStr, '?') !== false ? '&' : '?';
-                $queryParts = array_map(
-                    fn($l) => 'perfdatagraphs.label=' . rawurlencode($l),
-                    $newLabels
-                );
-                $urlStr .= $separator . implode('&', $queryParts);
-            }
-
             $list->add(Html::tag('li', Html::tag('a', [
-                'href'        => $urlStr,
-                'class'       => 'metric-label-link' . ($isSelected ? ' selected' : ''),
-                'data-label'  => $label,
-                'data-index'  => $index,
+                'href'       => '#',
+                'class'      => 'metric-label-link' . ($isSelected ? ' selected' : ''),
+                'data-label' => $label,
+                'data-index' => $index,
             ], $label)));
             $index++;
         }
 
         $this->add($list);
+        $this->add(Html::tag('div', ['class' => 'metric-selector-actions'], [
+            Html::tag('button', ['class' => 'metric-selector-apply', 'type' => 'button'],
+                $this->translate('Apply')),
+            Html::tag('button', ['class' => 'metric-selector-clear', 'type' => 'button'],
+                $this->translate('Clear')),
+        ]));
     }
 }

--- a/library/Perfdatagraphs/Widget/MetricSelector.php
+++ b/library/Perfdatagraphs/Widget/MetricSelector.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Icinga\Module\Perfdatagraphs\Widget;
+
+use ipl\Html\BaseHtmlElement;
+use ipl\Html\Html;
+use ipl\I18n\Translation;
+use ipl\Web\Url;
+
+/**
+ * MetricSelector renders a set of toggleable links — one per available
+ * perfdata metric, so the user can pick which charts to display.
+ * Each click adds/removes a perfdatagraphs.label URL param; IcingaWeb2
+ * intercepts the anchor clicks and reloads the tab content via AJAX.
+ */
+class MetricSelector extends BaseHtmlElement
+{
+    use Translation;
+    protected $tag = 'div';
+    protected $defaultAttributes = ['class' => 'perfdatagraphs-metric-selector'];
+    protected array $availableLabels;
+    protected array $selectedLabels;
+    protected Url $baseUrl;
+
+    /**
+     * @param string[] $availableLabels All metric labels returned by the backend
+     * @param string[] $selectedLabels  Labels currently selected (from URL params)
+     * @param Url      $baseUrl         Current request URL (used as link base)
+     */
+    public function __construct(array $availableLabels, array $selectedLabels, Url $baseUrl)
+    {
+        $this->availableLabels = $availableLabels;
+        $this->selectedLabels  = $selectedLabels;
+        $this->baseUrl         = $baseUrl;
+    }
+
+    protected function assemble(): void
+    {
+        if (empty($this->availableLabels)) {
+            return;
+        }
+
+        $this->add(Html::tag(
+            'p',
+            ['class' => 'metric-selector-title'],
+            $this->translate('Select metrics to display:')
+        ));
+
+        $list = Html::tag('ul', ['class' => 'metric-selector-list']);
+
+        foreach ($this->availableLabels as $label) {
+            $isSelected = in_array($label, $this->selectedLabels, true);
+
+            // Build the new set of selected labels after this toggle
+            if ($isSelected) {
+                $newLabels = array_values(array_filter(
+                    $this->selectedLabels,
+                    fn($l) => $l !== $label
+                ));
+            } else {
+                $newLabels = array_merge($this->selectedLabels, [$label]);
+            }
+
+            // Start from the base URL with all existing label params stripped
+            $urlStr = $this->baseUrl->without('perfdatagraphs.label')->getAbsoluteUrl();
+
+            // Append each desired label as a separate query param
+            if (!empty($newLabels)) {
+                $separator  = strpos($urlStr, '?') !== false ? '&' : '?';
+                $queryParts = array_map(
+                    fn($l) => 'perfdatagraphs.label=' . rawurlencode($l),
+                    $newLabels
+                );
+                $urlStr .= $separator . implode('&', $queryParts);
+            }
+
+            $list->add(Html::tag('li', Html::tag('a', [
+                'href'  => $urlStr,
+                'class' => 'metric-label-link' . ($isSelected ? ' selected' : ''),
+            ], $label)));
+        }
+
+        $this->add($list);
+    }
+}

--- a/public/css/module.less
+++ b/public/css/module.less
@@ -49,6 +49,60 @@ p.line-chart-error {
 }
 
 /*
+Metric selector: toggleable links shown above the charts
+so the user can choose which metrics to display.
+*/
+.perfdatagraphs-metric-selector {
+    margin-bottom: 1.5em;
+    padding-bottom: .75em;
+    border-bottom: 1px solid @gray-lighter;
+
+    .metric-selector-title {
+        margin: 0 0 .5em 0;
+        font-size: .8em;
+        font-weight: bold;
+        text-transform: uppercase;
+        letter-spacing: .05em;
+        color: @gray;
+    }
+
+    .metric-selector-list {
+        display: flex;
+        flex-wrap: wrap;
+        list-style: none;
+        margin: 0 -.25em;
+        padding: 0;
+
+        li {
+            margin: 0 .25em .4em;
+        }
+    }
+
+    a.metric-label-link {
+        display: inline-block;
+        padding: .2em .65em;
+        .rounded-corners(.25em);
+        border: 1px solid @gray-lighter;
+        background: @gray-lighter;
+        font-size: .85em;
+        text-decoration: none;
+        color: inherit;
+        white-space: nowrap;
+
+        &:hover {
+            border-color: @gray-semilight;
+            background: @gray-semilight;
+        }
+
+        &.selected {
+            background: @color-pending;
+            border-color: @color-pending;
+            color: white;
+        }
+    }
+}
+
+/*
 The spinner for when data is being fetched
 */
 i.spinner {

--- a/public/css/module.less
+++ b/public/css/module.less
@@ -100,6 +100,31 @@ so the user can choose which metrics to display.
             color: white;
         }
     }
+    .metric-selector-actions {
+        margin-top: .5em;
+        display: flex;
+        gap: .5em;
+
+        button {
+            padding: .25em .75em;
+            .rounded-corners(.25em);
+            border: 1px solid @gray-semilight;
+            cursor: pointer;
+            font-size: .85em;
+
+            &.metric-selector-apply {
+                background: @color-pending;
+                border-color: @color-pending;
+                color: white;
+                &:hover { opacity: .85; }
+            }
+
+            &.metric-selector-clear {
+                background: @gray-lighter;
+                &:hover { background: @gray-semilight; }
+            }
+        }
+    }
 }
 
 /*

--- a/public/js/module.js
+++ b/public/js/module.js
@@ -57,6 +57,8 @@
             // TODO: The 'rendered' selectors might not yet be optimal.
             this.on('rendered', '#main > .icinga-module, #main > .container', this.rendered, this);
             this.on('click', 'a.metric-label-link', this.onMetricLabelClick, this);
+            this.on('click', 'button.metric-selector-apply', this.onMetricSelectorApply, this);
+            this.on('click', 'button.metric-selector-clear', this.onMetricSelectorClear, this);
         }
 
         /**
@@ -607,53 +609,58 @@
          */
         onMetricLabelClick(event)
         {
-            let _this = event.data.self;
-            const $a = $(event.currentTarget);
-            const $selector = $a.closest('.perfdatagraphs-metric-selector');
-            const curIndex = parseInt($a.attr('data-index'), 10);
-
-            if (!event.shiftKey) {
-                // Normal click: record this pill as the anchor for future shift+clicks.
-                // Let IcingaWeb2 handle the actual navigation.
-                _this.lastClickedMetric.set($selector[0], curIndex);
-                return;
-            }
-
-            // Shift+click: select the range from last clicked to this pill.
             event.preventDefault();
             event.stopPropagation();
 
-            const $allLinks = $selector.find('a.metric-label-link');
-            const lastIndex = _this.lastClickedMetric.has($selector[0])
-                ? _this.lastClickedMetric.get($selector[0])
-                : curIndex;
+            const _this = event.data.self;
+            const $a = $(event.currentTarget);
+            const $selector = $a.closest('.perfdatagraphs-metric-selector');
+            const curIndex = parseInt($a.attr('data-index'), 10);
+            const selectorKey = $selector.attr('data-base-url');
 
-            const from = Math.min(lastIndex, curIndex);
-            const to   = Math.max(lastIndex, curIndex);
+            if (event.shiftKey && _this.lastClickedMetric.has(selectorKey)) {
+                // Shift+click: toggle all pills in the range
+                const lastIndex = _this.lastClickedMetric.get(selectorKey);
+                const from = Math.min(lastIndex, curIndex);
+                const to   = Math.max(lastIndex, curIndex);
+                const shouldSelect = !$a.hasClass('selected');
 
-            // Start from the currently selected set and add the entire range.
-            const selected = new Set(
-                $allLinks.filter('.selected').map((_, el) => $(el).attr('data-label')).get()
-            );
-            $allLinks.each((_, el) => {
-                const idx = parseInt($(el).attr('data-index'), 10);
-                if (idx >= from && idx <= to) {
-                    selected.add($(el).attr('data-label'));
-                }
-            });
+                $selector.find('a.metric-label-link').each((_, el) => {
+                    const idx = parseInt($(el).attr('data-index'), 10);
+                    if (idx >= from && idx <= to) {
+                        $(el).toggleClass('selected', shouldSelect);
+                    }
+                });
+            } else {
+                // Normal click: toggle just this pill
+                $a.toggleClass('selected');
+            }
 
-            // Build the new URL from the base URL stored on the container.
-            const baseUrl  = $selector.attr('data-base-url');
-            const sep      = baseUrl.includes('?') ? '&' : '?';
-            const newUrl   = selected.size > 0
-                ? baseUrl + sep + Array.from(selected)
-                    .map(l => 'perfdatagraphs.label=' + encodeURIComponent(l))
-                    .join('&')
+            _this.lastClickedMetric.set(selectorKey, curIndex);
+        }
+
+        onMetricSelectorApply(event)
+        {
+            event.preventDefault();
+            const _this = event.data.self;
+            const $selector = $(event.currentTarget).closest('.perfdatagraphs-metric-selector');
+            const baseUrl = $selector.attr('data-base-url');
+
+            const selected = $selector.find('a.metric-label-link.selected')
+                .map((_, el) => $(el).attr('data-label')).get();
+
+            const sep = baseUrl.includes('?') ? '&' : '?';
+            const newUrl = selected.length > 0
+                ? baseUrl + sep + selected.map(l => 'perfdatagraphs.label=' + encodeURIComponent(l)).join('&')
                 : baseUrl;
+            _this.icinga.loader.loadUrl(newUrl, $selector.closest('.container'));
+        }
 
-            // Update the anchor and navigate via IcingaWeb2 loader.
-            _this.lastClickedMetric.set($selector[0], curIndex);
-            _this.icinga.loader.loadUrl(newUrl, $a.closest('.container'));
+        onMetricSelectorClear(event)
+        {
+            event.preventDefault();
+            const $selector = $(event.currentTarget).closest('.perfdatagraphs-metric-selector');
+            $selector.find('a.metric-label-link').removeClass('selected');
         }
     }
     Icinga.Behaviors.Perfdatagraphs = Perfdatagraphs;

--- a/public/js/module.js
+++ b/public/js/module.js
@@ -16,7 +16,9 @@
         currentSelect = null;
         currentCursor = null;
         currentSeriesShow = {};
-
+        // Tracks the last normally-clicked metric pill per selector container,
+        // used to compute the range on shift+click.
+        lastClickedMetric = new Map();
         constructor(icinga)
         {
             super(icinga);
@@ -54,6 +56,7 @@
 
             // TODO: The 'rendered' selectors might not yet be optimal.
             this.on('rendered', '#main > .icinga-module, #main > .container', this.rendered, this);
+            this.on('click', 'a.metric-label-link', this.onMetricLabelClick, this);
         }
 
         /**
@@ -596,6 +599,62 @@
 
             return nullGaps;
         }
+    }
+
+        /**
+         * onMetricLabelClick handles clicks on metric selector pills.
+         * Normal clicks are passed through to IcingaWeb2's own handler (navigation).
+         * Shift+click selects all pills between the last clicked pill and this one.
+         */
+        onMetricLabelClick(event)
+        {
+            let _this = event.data.self;
+            const $a = $(event.currentTarget);
+            const $selector = $a.closest('.perfdatagraphs-metric-selector');
+            const curIndex = parseInt($a.attr('data-index'), 10);
+
+            if (!event.shiftKey) {
+                // Normal click: record this pill as the anchor for future shift+clicks.
+                // Let IcingaWeb2 handle the actual navigation.
+                _this.lastClickedMetric.set($selector[0], curIndex);
+                return;
+            }
+
+            // Shift+click: select the range from last clicked to this pill.
+            event.preventDefault();
+            event.stopPropagation();
+
+            const $allLinks = $selector.find('a.metric-label-link');
+            const lastIndex = _this.lastClickedMetric.has($selector[0])
+                ? _this.lastClickedMetric.get($selector[0])
+                : curIndex;
+
+            const from = Math.min(lastIndex, curIndex);
+            const to   = Math.max(lastIndex, curIndex);
+
+            // Start from the currently selected set and add the entire range.
+            const selected = new Set(
+                $allLinks.filter('.selected').map((_, el) => $(el).attr('data-label')).get()
+            );
+            $allLinks.each((_, el) => {
+                const idx = parseInt($(el).attr('data-index'), 10);
+                if (idx >= from && idx <= to) {
+                    selected.add($(el).attr('data-label'));
+                }
+            });
+
+            // Build the new URL from the base URL stored on the container.
+            const baseUrl  = $selector.attr('data-base-url');
+            const sep      = baseUrl.includes('?') ? '&' : '?';
+            const newUrl   = selected.size > 0
+                ? baseUrl + sep + Array.from(selected)
+                    .map(l => 'perfdatagraphs.label=' + encodeURIComponent(l))
+                    .join('&')
+                : baseUrl;
+
+            // Update the anchor and navigate via IcingaWeb2 loader.
+            _this.lastClickedMetric.set($selector[0], curIndex);
+            _this.icinga.loader.loadUrl(newUrl, $a.closest('.container'));
     }
 
     Icinga.Behaviors.Perfdatagraphs = Perfdatagraphs;

--- a/public/js/module.js
+++ b/public/js/module.js
@@ -599,7 +599,6 @@
 
             return nullGaps;
         }
-    }
 
         /**
          * onMetricLabelClick handles clicks on metric selector pills.
@@ -655,8 +654,8 @@
             // Update the anchor and navigate via IcingaWeb2 loader.
             _this.lastClickedMetric.set($selector[0], curIndex);
             _this.icinga.loader.loadUrl(newUrl, $a.closest('.container'));
+        }
     }
-
     Icinga.Behaviors.Perfdatagraphs = Perfdatagraphs;
 
 }(Icinga, jQuery));


### PR DESCRIPTION
Summary:

When navigating to the graphs tab for a service or host, all available metrics are now shown as a selectable list before any charts are rendered. Users can pick exactly which metrics they want to see rather than having all charts load at once.

Changes:

library/Perfdatagraphs/Widget/MetricSelector.php (new file). Renders a pill-style selector containing one link per available perfdata metric. Selected metrics are highlighted. Stores the stripped base URL for JavaScript to use. Includes Apply and Clear buttons.

library/Perfdatagraphs/ProvidedHook/Icingadb/Tab.php:

Collects available metric labels from the backend response. Renders the MetricSelector widget at the top of the tab. Only renders charts when at least one metric is selected. Falls back to the existing error/empty-state rendering when no data is available from the backend.

public/js/module.js:

Intercepts pill clicks: toggles selected state client-side (no page reload on each click) Shift+click selects or deselects all pills between the last clicked pill and the current one. Apply button builds the URL from currently selected pills and triggers a single AJAX reload. Clear button deselects all pills without reloading.

public/css/module.less:
Adds styles for the metric selector: flex-wrap pill list, gray unselected / blue selected state, Apply and Clear button styles.