### PR TITLE
Add metric selector to performance data graph tab

### DIFF
--- a/library/Perfdatagraphs/ProvidedHook/Icingadb/Tab.php
+++ b/library/Perfdatagraphs/ProvidedHook/Icingadb/Tab.php
@@ -7,6 +7,7 @@ use Icinga\Module\Perfdatagraphs\Common\PerfdataChart;
 use Icinga\Module\Perfdatagraphs\Common\PerfdataSource;
 use Icinga\Module\Perfdatagraphs\Icingadb\IcingaObjectHelper;
 use Icinga\Module\Perfdatagraphs\Model\PerfdataRequest;
+use Icinga\Module\Perfdatagraphs\Widget\MetricSelector;
 
 use Icinga\Module\Icingadb\Hook\TabHook;
 use Icinga\Module\Icingadb\Model\Host;
@@ -14,6 +15,7 @@ use Icinga\Module\Icingadb\Model\Service;
 
 use Icinga\Application\Icinga;
 
+use ipl\Web\Url;
 use ipl\Html\Html;
 use ipl\Html\HtmlElement;
 use ipl\Html\HtmlString;
@@ -66,9 +68,21 @@ class Tab extends TabHook
         // Retrieve the URL parameters.
         $duration = $request->getParam('perfdatagraphs_duration', $defaultDuration);
 
-        // Optional list of labels, when passed only the given perfdata metrics will be shown
-        $labels = $request->getUrl()->getParams()->getValues('perfdatagraphs.label');
+        // Optional list of labels, when passed only the given perfdata metrics will be shown.
+        // Support both repeated params (?perfdatagraphs.label=a&perfdatagraphs.label=b) and
+        // comma-separated single param (?perfdatagraphs.label=a,b) used by dashboard tile links.
+        $labels = [];
+        foreach ($request->getUrl()->getParams()->getValues('perfdatagraphs.label') as $raw) {
+            foreach (explode(',', $raw) as $label) {
+                $label = trim($label);
+                if ($label !== '') {
+                    $labels[] = $label;
+                }
+            }
+        }
 
+        // When noselector=1 the metric selector UI is suppressed (used by dashboard tiles).
+        $noSelector = $request->getUrl()->getParam('perfdatagraphs.noselector', '0') === '1';
         $cvh = new IcingaObjectHelper();
 
         $customvars = $cvh->getPerfdataGraphsConfigForObject($object);
@@ -108,13 +122,24 @@ class Tab extends TabHook
 
         $response = $source->fetch($request, $customVarsMetrics);
 
-        $limit = -1;
-        $chart = $this->createChart(request: $request, response: $response, filter: $labels, limit: $limit);
-        $content[] = HtmlString::create($chart);
+        // Collect all available metric labels from the response
+        $availableLabels = [];
+        foreach ($response->getDatasets() as $dataset) {
+            $availableLabels[] = $dataset->getTitle();
+        }
 
-        if (empty($chart)) {
-            $content[] = $this->addError($this->translate('Chart could not be rendered'));
-            return $content;
+        if (!empty($availableLabels) && !$noSelector) {
+            $content[] = new MetricSelector($availableLabels, $labels, Url::fromRequest());
+        }
+
+        if (!empty($labels)) {
+            // Render charts for the selected labels.
+            $chart = $this->createChart(request: $request, response: $response, filter: $labels, limit: -1);
+            $content[] = HtmlString::create($chart);
+        } elseif (empty($availableLabels)) {
+            // No datasets at all, fall through to standard empty/error rendering.
+            $chart = $this->createChart(request: $request, response: $response, filter: $labels, limit: -1);
+            $content[] = HtmlString::create($chart);
         }
 
         return $content;

--- a/library/Perfdatagraphs/ProvidedHook/Icingadb/Tab.php
+++ b/library/Perfdatagraphs/ProvidedHook/Icingadb/Tab.php
@@ -82,7 +82,10 @@ class Tab extends TabHook
         }
 
         // When noselector=1 the metric selector UI is suppressed (used by dashboard tiles).
-        $noSelector = $request->getUrl()->getParam('perfdatagraphs.noselector', '0') === '1';
+        // Do not suppress it for an empty selection, otherwise the tab returns no
+        // content and Icinga falls back to looking for a default view script.
+        $noSelector = $request->getUrl()->getParam('perfdatagraphs.noselector', '0') === '1'
+            && ! empty($labels);
         $cvh = new IcingaObjectHelper();
 
         $customvars = $cvh->getPerfdataGraphsConfigForObject($object);

--- a/library/Perfdatagraphs/Widget/MetricSelector.php
+++ b/library/Perfdatagraphs/Widget/MetricSelector.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Icinga\Module\Perfdatagraphs\Widget;
+
+use ipl\Html\BaseHtmlElement;
+use ipl\Html\Html;
+use ipl\I18n\Translation;
+use ipl\Web\Url;
+
+/**
+ * MetricSelector renders a checkbox list so the user can pick one or more
+ * perfdata metrics to display. The form uses GET so that IcingaWeb2 handles it
+ * via normal AJAX navigation, no custom javascript.
+ */
+class MetricSelector extends BaseHtmlElement
+{
+    use Translation;
+
+    protected $tag = 'div';
+
+    protected $defaultAttributes = ['class' => 'perfdatagraphs-metric-selector'];
+
+    /** @var string[] */
+    protected array $availableLabels;
+
+    /** @var string[] */
+    protected array $selectedLabels;
+
+    protected Url $baseUrl;
+
+    public function __construct(array $availableLabels, array $selectedLabels, Url $baseUrl)
+    {
+        $this->availableLabels = $availableLabels;
+        $this->selectedLabels  = $selectedLabels;
+        $this->baseUrl         = $baseUrl;
+    }
+
+    protected function assemble(): void
+    {
+        if (empty($this->availableLabels)) {
+            return;
+        }
+
+        // Build the form action (path only) and collect hidden inputs for
+        // all existing URL params except perfdatagraphs.label, which the
+        // <select> will supply.
+        $urlStr     = $this->baseUrl->without('perfdatagraphs.label')
+                                    ->without('perfdatagraphs.noselector')
+                                    ->getAbsoluteUrl();
+        $actionPath = $urlStr;
+        $hiddenInputs = [];
+
+        if (($qpos = strpos($urlStr, '?')) !== false) {
+            $actionPath = substr($urlStr, 0, $qpos);
+            foreach (explode('&', substr($urlStr, $qpos + 1)) as $pair) {
+                if ($pair === '') {
+                    continue;
+                }
+                [$name, $value] = array_pad(explode('=', $pair, 2), 2, '');
+                $hiddenInputs[] = Html::tag('input', [
+                    'type'  => 'hidden',
+                    'name'  => rawurldecode($name),
+                    'value' => rawurldecode($value),
+                ]);
+            }
+        }
+
+        $selectedCount = count($this->selectedLabels);
+        $labelText     = $selectedCount > 0
+            ? sprintf($this->translate('%d metric(s) selected'), $selectedCount)
+            : $this->translate('Select metrics');
+
+        // We use a hidden checkbox + label as a pure-CSS toggle.
+        // The checkbox has no name so it is never submitted with the form.
+        // IcingaWeb2 does not intercept <label> clicks, so this works reliably.
+        $toggleAttrs = ['type' => 'checkbox', 'id' => 'pfdg-metric-toggle', 'class' => 'metric-toggle-cb'];
+        if (empty($this->selectedLabels)) {
+            // Start the panel open when nothing is selected yet.
+            $toggleAttrs['checked'] = true;
+        }
+
+        // Items are wrapped in a scrollable div; submit button is a sibling
+        // below it so it stays visible outside the scroll area.
+        $checkboxList = Html::tag('div', ['class' => 'metric-checkbox-list']);
+        $itemsWrapper = Html::tag('div', ['class' => 'metric-items-scroll']);
+        foreach ($this->availableLabels as $label) {
+            $cbAttrs = [
+                'type'  => 'checkbox',
+                'name'  => 'perfdatagraphs.label',
+                'value' => $label,
+            ];
+            if (in_array($label, $this->selectedLabels, true)) {
+                $cbAttrs['checked'] = true;
+            }
+            $itemsWrapper->add(
+                Html::tag('label', ['class' => 'metric-item'], [
+                    Html::tag('input', $cbAttrs),
+                    Html::tag('span', [], $label),
+                ])
+            );
+        }
+
+        $checkboxList->add($itemsWrapper);
+        $checkboxList->add(
+            Html::tag('div', ['class' => 'metric-selector-submit-row icinga-controls'],
+                Html::tag('button', ['type' => 'submit', 'name' => 'undefined'], $this->translate('Show'))
+            )
+        );
+
+        $form = Html::tag('form', [
+            'method'           => 'get',
+            'action'           => $actionPath,
+            'data-base-target' => '_self',
+        ]);
+        foreach ($hiddenInputs as $input) {
+            $form->add($input);
+        }
+        // noselector=1 is baked into the submitted URL so that dashboard tiles
+        // (which capture the current URL) suppress the selector widget.
+        $form->add(Html::tag('input', [
+            'type'  => 'hidden',
+            'name'  => 'perfdatagraphs.noselector',
+            'value' => '1',
+        ]));
+        $form->add(Html::tag('input', $toggleAttrs));
+        $form->add(Html::tag('label', ['for' => 'pfdg-metric-toggle', 'class' => 'metric-toggle-label'], $labelText));
+        $form->add($checkboxList);
+
+        $this->add($form);
+    }
+}

--- a/library/Perfdatagraphs/Widget/MetricSelector.php
+++ b/library/Perfdatagraphs/Widget/MetricSelector.php
@@ -103,7 +103,8 @@ class MetricSelector extends BaseHtmlElement
         $checkboxList->add($itemsWrapper);
         $checkboxList->add(
             Html::tag('div', ['class' => 'metric-selector-submit-row icinga-controls'],
-                Html::tag('button', ['type' => 'submit', 'name' => 'undefined'], $this->translate('Show'))
+                Html::tag('button', ['type' => 'submit', 'name' => 'undefined'],
+                    $this->translate('Show'))
             )
         );
 

--- a/public/css/module.less
+++ b/public/css/module.less
@@ -142,6 +142,7 @@ styled to match IcingaWeb2's flyout dropdown look.
         margin: 0 .4em 0 0;
         background: none;
         border: none;
+        outline: none;
         flex-shrink: 0;
 
         &:checked::before {

--- a/public/css/module.less
+++ b/public/css/module.less
@@ -48,6 +48,119 @@ p.line-chart-error {
     text-overflow: ellipsis;
 }
 
+
+/*
+Metric selector: CSS-only collapsible dropdown with checkboxes,
+styled to match IcingaWeb2's flyout dropdown look.
+*/
+.perfdatagraphs-metric-selector {
+    position: relative;
+    display: inline-block;
+    margin-bottom: 1em;
+
+    .metric-toggle-cb {
+        position: absolute;
+        width: 0;
+        height: 0;
+        visibility: hidden;
+    }
+
+    .metric-toggle-label {
+        display: inline-flex;
+        align-items: center;
+        gap: .4em;
+        padding: @vertical-padding @horizontal-padding;
+        border: 1px solid @gray-semilight;
+        .rounded-corners(.25em);
+        background: @body-bg-color;
+        color: @text-color;
+        cursor: pointer;
+        user-select: none;
+        font-size: inherit;
+
+        &::after {
+            content: '\25BE';
+            font-size: .9em;
+            margin-left: .2em;
+        }
+    }
+
+    .metric-toggle-cb:checked ~ .metric-toggle-label::after {
+        content: '\25B4';
+    }
+
+    .metric-checkbox-list {
+        display: none;
+    }
+
+    .metric-toggle-cb:checked ~ .metric-checkbox-list {
+        display: flex;
+        flex-direction: column;
+        position: absolute;
+        z-index: 200;
+        top: 100%;
+        left: 0;
+        min-width: 14em;
+        max-width: 30em;
+        margin-top: .2em;
+        background: fade(@menu-flyout-bg-color, 92%);
+        border: 1px solid @gray-light;
+        .rounded-corners(.25em);
+        box-shadow: .2em .3em .6em 0 rgba(0,0,0,.3);
+    }
+
+    .metric-items-scroll {
+        overflow-y: auto;
+        max-height: 300px;
+        padding: .3em 0;
+    }
+
+    label.metric-item {
+        display: flex;
+        align-items: center;
+        padding: .3em .75em .3em .5em;
+        cursor: pointer;
+        white-space: nowrap;
+        color: @text-color;
+        user-select: none;
+
+        &:hover {
+            background: @tr-active-color;
+        }
+
+        &:has(input:checked) {
+            color: @icinga-blue;
+        }
+    }
+
+    label.metric-item input[type="checkbox"] {
+        appearance: none;
+        -webkit-appearance: none;
+        width: 1.1em;
+        min-width: 1.1em;
+        height: 1em;
+        margin: 0 .4em 0 0;
+        background: none;
+        border: none;
+        flex-shrink: 0;
+
+        &:checked::before {
+            content: '\2713';
+            display: block;
+            color: @icinga-blue;
+            font-weight: bold;
+            line-height: 1;
+        }
+    }
+
+    .metric-selector-submit-row {
+        display: block;
+        padding: .4em .5em;
+        border-top: 1px solid @gray-semilight;
+        flex-shrink: 0;
+    }
+}
+
 /*
 The spinner for when data is being fetched
 */

--- a/public/js/module.js
+++ b/public/js/module.js
@@ -16,6 +16,8 @@
         currentSelect = null;
         currentCursor = null;
         currentSeriesShow = {};
+        // Last clicked metric label for shift click range selection
+        lastMetricClick = null;
 
         constructor(icinga)
         {
@@ -54,6 +56,7 @@
 
             // TODO: The 'rendered' selectors might not yet be optimal.
             this.on('rendered', '#main > .icinga-module, #main > .container', this.rendered, this);
+            this.on('click', '.perfdatagraphs-metric-selector .metric-item', this.onMetricItemClick, this);
         }
 
         /**
@@ -80,6 +83,19 @@
             });
             // Then, reset the existing plots map for the new rendering
             _this.plots = new Map();
+
+            // IcingaWeb2 restores form state after AJAX navigation, which can
+            // leave the metric selector toggle checked (open) even though metrics
+            // are already selected. Force-close it whenever metrics are selected.
+            document.querySelectorAll('.perfdatagraphs-metric-selector').forEach(sel => {
+                const toggle = sel.querySelector('.metric-toggle-cb');
+                if (toggle && sel.querySelectorAll('.metric-items-scroll input:checked').length > 0) {
+                    toggle.checked = false;
+                }
+            });
+
+            // Reset shift click anchor on every render
+            _this.lastMetricClick = null;
 
             // Get the elements we going to render the charts in
             const lineCharts = document.querySelectorAll(CHART_CLASS);
@@ -596,6 +612,43 @@
 
             return nullGaps;
         }
+
+        /**
+         * onMetricItemClick handles clicks on metric selector labels.
+         * Shift click selects/deselects a range of checkboxes between the last
+         * clicked item and the current one.
+         */
+        onMetricItemClick(event)
+        {
+            const _this = event.data.self;
+            const label = event.currentTarget;
+
+            if (event.shiftKey && _this.lastMetricClick !== null) {
+                // Prevent text selection that browsers do on shift-click.
+                event.preventDefault();
+
+                const list = label.closest('.metric-items-scroll');
+                if (list) {
+                    const labels = Array.from(list.querySelectorAll('label.metric-item'));
+                    const lastIdx = labels.indexOf(_this.lastMetricClick);
+                    const currIdx = labels.indexOf(label);
+
+                    if (lastIdx !== -1 && currIdx !== -1) {
+                        // Apply the same checked state as the anchor item.
+                        const anchorCb = _this.lastMetricClick.querySelector('input[type="checkbox"]');
+                        const newState = anchorCb ? anchorCb.checked : true;
+                        const from = Math.min(lastIdx, currIdx);
+                        const to   = Math.max(lastIdx, currIdx);
+                        for (let i = from; i <= to; i++) {
+                            const cb = labels[i].querySelector('input[type="checkbox"]');
+                            if (cb) cb.checked = newState;
+                        }
+                    }
+                }
+            }
+
+            _this.lastMetricClick = label;
+        }    
     }
 
     Icinga.Behaviors.Perfdatagraphs = Perfdatagraphs;


### PR DESCRIPTION
Summary:

This change adds a collapsible metric selector to the IcingaDB performance data graph tab so users can choose which perfdata metrics to display instead of always showing all metrics

Changes:

New file library Perfdatagraphs Widget MetricSelector.php. New MetricSelector widget that renders a CSS only collapsible dropdown with one checkbox for each available metric. Uses GET form submission so IcingaWeb2 handles navigation normally without custom ajax handling

Adds perfdatagraphs.noselector=1 to submitted URLs so dashboard tiles can suppress the selector and show only the chart

Parses perfdatagraphs label with support for both repeated parameters and comma separated values used by dashboard tile links, maybe we only want one as they do the same thing. 

Collects available metric labels from response datasets. Shows the metric selector only when datasets are available and noselector is not enabled, might want to add default behavior when only one metric is available. 

Updated file public css module.less:
Adds styling for the metric selector to better match the IcingaWeb2 look. Uses CSS only open and close behavior through checked sibling selectors. 

Adds custom checkbox styling and selected state highlighting.

Updated file public js module.js:
Adds shift click range selection for metric checkboxes, some JS was needed for this to work.
Closes the selector flyout on rendered when metrics are already selected so ajax navigation does not leave it open