### PR TITLE
Sort charts with strnatcmp

### DIFF
--- a/library/Perfdatagraphs/Common/PerfdataChart.php
+++ b/library/Perfdatagraphs/Common/PerfdataChart.php
@@ -110,7 +110,14 @@ trait PerfdataChart
         }
 
         $datasets = [];
-        foreach ($response->getDatasets() as $dataset) {
+
+        // Ensure labels have a predictable order
+        $sets = $response->getDatasets();
+        uasort($sets, function ($a, $b) {
+            return strnatcmp($a->getTitle(), $b->getTitle());
+        });
+
+        foreach ($sets as $dataset) {
             // If the filter param is set, we only use the dataset when the label matches
             if (count($filter) > 0) {
                 if (!in_array($dataset->getTitle(), $filter)) {


### PR DESCRIPTION
This PR sorts the charts by the perfdata labels using strnatcmp. This makes sure that labels like "load1", "load15", "load5" are sorted properly. 

I opted to not use `Icingadb\Util\PerfDataSet` because I wanted to avoid its parsing of the perfdata, since we already have the labels and values directly from the backend.

Fixes #102 