### PR TITLE
Introduce global disable_objectview_graphs_rendering setting

### DIFF
--- a/application/forms/PerfdataGraphsConfigForm.php
+++ b/application/forms/PerfdataGraphsConfigForm.php
@@ -91,6 +91,14 @@ class PerfdataGraphsConfigForm extends ConfigForm
             'class' => 'autosubmit',
         ]);
 
+        $this->addElement('checkbox', 'perfdatagraphs_disable_objectview_graphs_rendering', [
+            'label' => t('Disable rendering graphs on object detail views'),
+            'description' => t('Disable rendering graphs on object detail views.' .
+                               ' Graphs can then only be viewed in their dedicated tab.'),
+            'value' => (bool) $this->config->get('perfdatagraphs', 'disable_objectview_graphs_rendering', false),
+            'class' => 'autosubmit',
+        ]);
+
         $backends = $this->listBackends();
         $choose = ['' => sprintf(' - %s - ', t('Please choose'))];
 

--- a/doc/03-Configuration.md
+++ b/doc/03-Configuration.md
@@ -19,6 +19,9 @@ cache_lifetime = 9000
 # Disable rendering of all warning and critical thresholds by default. They can still be toggled in the interface.
 # Note, this will override the custom variable show_threshold of the object.
 disable_thresholds_rendering = "0"
+
+# Disable rendering of graphs in the object detail view. Graphs can then only be viewed in their dedicated tab.
+disable_objectview_graphs_rendering = "0"
 ```
 
 Note, the module respects the HTTP Header "Cache-Control" (no-cache) to disable the cache.

--- a/library/Perfdatagraphs/Common/ModuleConfig.php
+++ b/library/Perfdatagraphs/Common/ModuleConfig.php
@@ -88,6 +88,7 @@ class ModuleConfig
             'default_timerange' => 'PT12H',
             'minimum_chart_count' => 3,
             'disable_thresholds_rendering' => false,
+            'disable_objectview_graphs_rendering' => false,
         ];
 
         // Try to load the configuration
@@ -106,6 +107,7 @@ class ModuleConfig
         $config['minimum_chart_count'] = (int) $moduleConfig->get('perfdatagraphs', 'minimum_chart_count', $default['minimum_chart_count']);
         $config['default_timerange'] = $moduleConfig->get('perfdatagraphs', 'default_timerange', $default['default_timerange']);
         $config['disable_thresholds_rendering'] = (bool) $moduleConfig->get('perfdatagraphs', 'disable_thresholds_rendering', $default['disable_thresholds_rendering']);
+        $config['disable_objectview_graphs_rendering'] = (bool) $moduleConfig->get('perfdatagraphs', 'disable_objectview_graphs_rendering', $default['disable_objectview_graphs_rendering']);
 
         return $config;
     }

--- a/library/Perfdatagraphs/ProvidedHook/Icingadb/HostDetailExtension.php
+++ b/library/Perfdatagraphs/ProvidedHook/Icingadb/HostDetailExtension.php
@@ -29,6 +29,13 @@ class HostDetailExtension extends HostDetailExtensionHook
      */
     public function getHtmlForObject(Host $host): ValidHtml
     {
+        // Load the module's configuration.
+        $config = ModuleConfig::getConfigWithDefaults();
+
+        if ($config['disable_objectview_graphs_rendering']) {
+            return Html::tag('div');
+        }
+
         $serviceName = $host->checkcommand_name ?? '';
         $hostName = $host->name ?? '';
         $checkCommandName = $host->checkcommand_name ?? '';
@@ -67,8 +74,6 @@ class HostDetailExtension extends HostDetailExtensionHook
             $metricsToExclude = $customvars[$cvh::CUSTOM_VAR_CONFIG_EXCLUDE];
         }
 
-        // Load the module's configuration.
-        $config = ModuleConfig::getConfigWithDefaults();
         $duration = $config['default_timerange'];
         // When there is a parameter for the duration we use that instead.
         if (Url::fromRequest()->hasParam('perfdatagraphs.duration')) {

--- a/library/Perfdatagraphs/ProvidedHook/Icingadb/ServiceDetailExtension.php
+++ b/library/Perfdatagraphs/ProvidedHook/Icingadb/ServiceDetailExtension.php
@@ -29,6 +29,13 @@ class ServiceDetailExtension extends ServiceDetailExtensionHook
      */
     public function getHtmlForObject(Service $service): ValidHtml
     {
+        // Load the module's configuration.
+        $config = ModuleConfig::getConfigWithDefaults();
+
+        if ($config['disable_objectview_graphs_rendering']) {
+            return Html::tag('div');
+        }
+
         $serviceName = $service->name ?? '';
         $hostName = $service->host->name ?? '';
         $checkCommandName = $service->checkcommand_name ?? '';
@@ -67,8 +74,6 @@ class ServiceDetailExtension extends ServiceDetailExtensionHook
             $metricsToExclude = $customvars[$cvh::CUSTOM_VAR_CONFIG_EXCLUDE];
         }
 
-        // Load the module's configuration.
-        $config = ModuleConfig::getConfigWithDefaults();
         $duration = $config['default_timerange'];
         // When there is a parameter for the duration we use that instead.
         if (Url::fromRequest()->hasParam('perfdatagraphs.duration')) {

--- a/library/Perfdatagraphs/ProvidedHook/Monitoring/DetailviewExtension.php
+++ b/library/Perfdatagraphs/ProvidedHook/Monitoring/DetailviewExtension.php
@@ -24,6 +24,13 @@ class DetailviewExtension extends DetailviewExtensionHook
 
     public function getHtmlForObject(MonitoredObject $object)
     {
+        // Load the module's configuration.
+        $config = ModuleConfig::getConfigWithDefaults();
+
+        if ($config['disable_objectview_graphs_rendering']) {
+            return Html::tag('div');
+        }
+
         $isHostCheck = false;
 
         if ($object instanceof Host) {
@@ -63,8 +70,6 @@ class DetailviewExtension extends DetailviewExtensionHook
             return $err;
         }
 
-        // Load the module's configuration.
-        $config = ModuleConfig::getConfigWithDefaults();
         $duration = $config['default_timerange'];
         // When there is a parameter for the duration we use that instead.
         if (Url::fromRequest()->hasParam('perfdatagraphs.duration')) {


### PR DESCRIPTION
This PR adds a new option to disable rendering graphs on object detail views. Graphs can then only be viewed in their dedicated tab.

Fixes #135 